### PR TITLE
Reduce core and add plugin capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ fixtureFactory('user', userDataModel);
 fixtureFactory.generateOne('user');
 ```
 
-will generate
+Expected Output
 
 ```
 {
@@ -39,7 +39,7 @@ will generate
 ```
 fixtureFactory.generate('user', 10);
 ```
-will generate
+Expected Output
 
 ```
 [{
@@ -47,6 +47,66 @@ will generate
   lastName: <generated last name>
 }, ... 9 more
 ]
+```
+
+### Generate nested objects
+
+```
+fixtureFactory.register('user',{
+    type: 'admin',
+    firstName: 'Daniel',
+    role: {
+        id: 'random.uuid',
+        name: 'internet.userName'
+    }
+  });
+
+fixtureFactory.generateOne('user');
+```
+
+Expected Output
+
+```
+{ type: 'admin',
+  firstName: 'Daniel',
+  role:
+  {
+     id: '15751f0a-569d-4789-89cc-8f7c8405f007',
+     name: 'German_Glover10'
+  }
+}
+```
+
+### Generate array of nested objects
+
+```
+fixtureFactory.register('user',{
+    type: 'admin',
+    firstName: 'Daniel',
+    roles: [{
+        id: 'random.uuid',
+        name: 'internet.userName'
+    }, 10]
+  });
+
+fixtureFactory.generateOne('user');
+```
+
+Expected Output
+
+```
+{ type: 'admin',
+  firstName: 'Daniel',
+  roles:
+  [
+     {
+       id: '1b8df9da-3f1a-4f9b-ab96-1de8cc4844c5',
+       name: 'Dawn_Dooley30'
+     },
+     ... 9 more
+  ]
+}
+
 ```
 
 ### Generate with extra fields
@@ -58,7 +118,7 @@ fixtureFactory.generate('user',1 ,{
   });
 ```
 
-will generate
+Expected Output
 
 ```
 {
@@ -75,7 +135,7 @@ fixtureFactory.generateOne({
   email: 'internet.email'
   });
 ```
-will generate
+Expected Output
 
 ```
 {
@@ -108,7 +168,7 @@ var userDataModel = {
 fixtureFactory.register('user', userDataModel);
 fixtureFactory.generateOne('user');
 ```
-will generate
+Expected Output
 ```
 {
  staticField: 'someValue'
@@ -132,7 +192,7 @@ var userDataModel = {
 fixtureFactory.register('user', userDataModel);
 fixtureFactory.generateOne('user');
 ```
-will generate
+Expected Output
 ```
 {
  staticField: '<generated name>@acme.com'
@@ -159,7 +219,7 @@ var userDataModel = {
 fixtureFactory.register('user', userDataModel);
 fixtureFactory.generateOne();
 ```
-will generate
+Expected Output
 ```
 {
  age: <number between 18 and 90>
@@ -187,16 +247,119 @@ fixtureFactory.generateOne('user', {
 });
 
 ```
-will generate
+Expected Output
 ```
 {
  firstName: 'sir <some generated name>'
 }
 ```
 
+## Reference Plugin
 
+The Reference plugin an examle extension of the fixture factory that allows
+embeding other models into your models. It is enabled by default.
 
+#### Embed another model in your fixture
 
+```
+fixtureFactory.register('user',{
+  type: 'admin',
+  firstName: 'Daniel'
+});
+
+fixtureFactory.register('role',{
+  id: 'random.uuid',
+  name: 'internet.userName'
+});
+
+fixtureFactory.generateOne('user', {
+  role: 'model.role'  
+});
+```
+
+Expected Output
+
+```
+{
+  type: 'admin',
+  firstName: 'Daniel',
+  role:
+  {
+     id: '15751f0a-569d-4789-89cc-8f7c8405f007',
+     name: 'German_Glover10'
+  }
+}
+
+```
+
+#### Embed another model in your fixture and provide properties
+
+```
+fixtureFactory.register('user',{
+  type: 'admin',
+  firstName: 'Daniel'
+});
+
+fixtureFactory.register('role',{
+  id: 'random.uuid',
+  name: 'internet.userName'
+});
+
+fixtureFactory.generateOne('user', {
+  role: {
+    method: 'model.role',
+    reference: {
+      properties: {
+        active: true
+      }
+    }
+  }
+});
+```
+
+Expected Output
+
+```
+{
+  type: 'admin',
+  firstName: 'Daniel',
+  role:
+  {
+    id: '8b23b7f8-c14b-4231-a768-5ecc407a5821',
+    name: 'Dianna36',
+    active: true
+  }
+}
+
+```
+
+#### Embed another model field in your fixture
+
+```
+fixtureFactory.register('user',{
+  type: 'admin',
+  firstName: 'Daniel'
+});
+
+fixtureFactory.register('role',{
+  id: 'random.uuid',
+  name: 'internet.userName'
+});
+
+fixtureFactory.generateOne('user', {
+  roleId: 'model.role.id'  
+});
+```
+
+Expected Output
+
+```
+{
+  type: 'admin',
+  firstName: 'Daniel',
+  roleId: '17b6ec69-606d-4e97-b2c5-4eb9b3507e32'
+}
+```
 
 ## TO DO
 - add support for defining own generators

--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ Expected Output
 
 ## Reference Plugin
 
-The Reference plugin an examle extension of the fixture factory that allows
-embeding other models into your models. It is enabled by default.
+The Reference plugin is an example extension of the fixture factory that allows
+embeding other models into your definition. It is enabled by default.
 
 #### Embed another model in your fixture
 

--- a/index.js
+++ b/index.js
@@ -2,19 +2,26 @@
 
 var faker = require('faker');
 var _ = require('lodash');
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
+var referencePlugin = require('./plugins/reference');
 
 var instance;
 
 function FixtureFactory () {
   this.dataModels = {};
-  this.createdModels = {};
+  EventEmitter.call(this);
+  referencePlugin.enable(this);
 }
 
-var _getFieldModel = function (method) {
-  return !_.isFunction(method) && _.isObject(method) ? method : { method: method };
+util.inherits(FixtureFactory, EventEmitter);
+
+FixtureFactory.prototype._getFieldModel = function (method) {
+  var transform = !_.isFunction(method) && _.isObject(method) && method.method;
+  return transform ? method : { method: method };
 };
 
-var _handleFunction = function (model, fixture, dataModel) {
+FixtureFactory.prototype._handleFunction = function (model, fixture, dataModel) {
   return model.method.call(
     null,
     fixture,
@@ -24,10 +31,11 @@ var _handleFunction = function (model, fixture, dataModel) {
   );
 };
 
-var _handleString = function (model) {
+FixtureFactory.prototype._handleString = function (model) {
   var callStack = model.method.split('.');
   var nestedFakerMethod = faker;
   var isMethod = true;
+  var options = model.options ? _.cloneDeep(model.options) : void 0;
   var nextMethod;
 
   while (callStack.length) {
@@ -40,88 +48,105 @@ var _handleString = function (model) {
     }
   }
 
-  return isMethod ? nestedFakerMethod(_.cloneDeep(model.options || { })) : model.method;
+  return isMethod ? nestedFakerMethod(options) : model.method;
 };
 
-var _generateField = function (key, method, fixture, dataModel, generatedFixtures) {
+FixtureFactory.prototype._formatNest = function (nested) {
+  var result = {};
 
-  var fieldModel = _getFieldModel(method);
+  if (_.isArray(nested)) {
+    result.context = nested[0];
+    result.count = nested[1] || 1;
+  } else if (_.isString(nested)) {
+    split = nested.split('.');
+    result.context = this.dataModels[split[0]];
+
+    if (split.length === 2) {
+      result.context = {};
+      result.context[split[1]] = this.dataModels[split[0]][split[1]];
+    }
+  } else if (nested.context){
+    result = nested;
+  } else {
+
+  }
+
+  return result;
+};
+
+FixtureFactory.prototype._generateField = function (
+  key, method, fixture, dataModel, generatedFixtures
+) {
+  var fieldModel = this._getFieldModel(method);
+  var count;
   var field;
 
-  // if the field has a nested object - return it
-  if (fieldModel.nest) {
-    return fieldModel.nest;
-  }
+  this.emit('field:pre', {
+    name: key,
+    model: fieldModel
+  });
 
-  if (fieldModel.reference) {
+  console.log(fieldModel);
 
-    var split = fieldModel.reference.split('.');
-    var referencedModelName = split[0];
-    var referencedFieldName = split[1];
-
-    // check if model of given name was already generated
-    if (!instance.createdModels[referencedModelName]) {
-      throw new Error('Requested model "' + referencedModelName + '" has not yet been created');
-    }
-
-    // randomly pick and return one of values of referenced field from all referenced models
-    var possibleValues = _.pluck(instance.createdModels[referencedModelName], referencedFieldName);
-    var index = _.random(0, possibleValues.length - 1);
-
-    return possibleValues[index];
-
-  }
+  var count = 1;
 
   switch (typeof fieldModel.method) {
-
     case 'function':
-      field = _handleFunction(fieldModel, fixture, dataModel);
+      field = this._handleFunction(fieldModel, fixture, dataModel);
       break;
 
     case 'string':
-      field = _handleString(fieldModel);
+      field = this._handleString(fieldModel);
+      break;
+
+    case 'number':
+    case 'boolean':
+      field = fieldModel.method;
       break;
 
     // method is an object so just return it
     default :
-      field = fieldModel.method;
+      if (_.isArray(fieldModel.method)) {
+        count = fieldModel.method[1] || 1;
+      } else {
+        fieldModel.method = [fieldModel.method];
+      }
+
+      field = this.generate.apply(this, fieldModel.method);
+
+      if (count === 1) {
+        field = field[0];
+      }
   }
 
-  // If the current field is unique, make sure
-  // that it is not duplicated
-  if (fieldModel.unique === true) {
-
-    // Check if current value exists in fixtures generated thus far
-    if (_.some(_.pluck(generatedFixtures, key), function (existingValue) {
-      return existingValue === field;
-    })) {
-      return _generateField.apply(null, arguments);
-    }
-  }
+  this.emit('field', {
+    name: key,
+    value: field,
+    model: fieldModel
+  });
 
   return field;
 };
 
-var _generateFixture = function (context, properties, generatedFixtures) {
-
-  properties = properties || {};
-
+FixtureFactory.prototype._generateFixture = function (context, properties, generatedFixtures) {
   // check if raw model definition was passed or should we fetch it from the registered ones
   var dataModel = _.isObject(context) ? context : this.dataModels[context] || {};
+  var name = _.isObject(context) ? void 0 : context;
   var fixture = {};
+  var fieldGenerators = {};
+  var self = this;
+
+  properties = properties || {};
 
   // if user passed additional properties extend the dataModel with them
   dataModel = _.extend({}, dataModel, properties);
 
-  // check if we need to worry about combined unique fields later
-  // combined unique as pairs of keys etc
-  var uniqueFields;
-  if (dataModel._combinedUnique != null) {
-    uniqueFields = dataModel._combinedUnique;
-    delete dataModel._combinedUnique;
-  }
-
-  var fieldGenerators = {};
+  this.emit('fixture:pre', {
+    model: dataModel,
+    name: name,
+    properties: properties,
+    generated: generatedFixtures
+  });
 
   _.each(dataModel, function (value, key) {
 
@@ -129,124 +154,103 @@ var _generateFixture = function (context, properties, generatedFixtures) {
 
     // if field has a generator function assigned to it, cache it for later
     if (!_.isFunction(value) && !_.isFunction(value.method)) {
-      fixture[key] = _generateField(key, value, fixture, dataModel, generatedFixtures);
+      fixture[key] = self._generateField(key, value, fixture, dataModel, generatedFixtures);
     } else {
       fieldGenerators[key] = value;
     }
-
   });
 
   _.each(fieldGenerators, function (fieldGenerator, key) {
-    fixture[key] = _generateField(key, fieldGenerator, fixture, dataModel, generatedFixtures);
+    fixture[key] = self._generateField(
+      key,
+      fieldGenerator,
+      fixture,
+      dataModel,
+      generatedFixtures
+    );
   });
 
-  if (uniqueFields) {
-
-    // check if there are not matching sets of combined uniquer values
-    var notUnique = !!_.some(generatedFixtures, function (generatedFixture) {
-      return _.every(uniqueFields, function (uniqueField) {
-        return generatedFixture[uniqueField] === fixture[uniqueField];
-      });
-    });
-
-    // if it does generate the whole fixture again
-    if (notUnique) {
-      return _generateFixture.apply(this, arguments);
-    }
-
-  }
+  this.emit('fixture', {
+    fixture: fixture,
+    name: name,
+    properties: properties,
+    generated: generatedFixtures
+  });
 
   return fixture;
-
 };
 
-FixtureFactory.prototype = {
+FixtureFactory.prototype.noConflict = function () {
+  return new FixtureFactory();
+};
 
-  noConflict: function () {
-    return new FixtureFactory();
-  },
+FixtureFactory.prototype.getGenerator = function (key) {
+  var self = this;
 
-  getGenerator: function (key) {
-
-    var self = this;
-
-    return {
-      generate: function () {
-        self.generate.apply(self, _.union([key], arguments));
-      },
-      generateOne: function () {
-        self.generateOne.apply(self, _.union([key], arguments));
-      }
-    };
-
-  },
-
-  register: function (key, dataModel) {
-
-    var models;
-
-    if (typeof key === 'string') {
-      models = {};
-      models[key] = dataModel;
-    }  else {
-      models = key;
+  return {
+    generate: function () {
+      self.generate.apply(self, _.union([key], arguments));
+    },
+    generateOne: function () {
+      self.generateOne.apply(self, _.union([key], arguments));
     }
+  };
+};
 
-    _.extend(this.dataModels, models);
+FixtureFactory.prototype.register = function (key, dataModel) {
+  var models = {};
+  var isString = typeof key === 'string';
 
-    return this;
-
-  },
-
-  reset: function () {
-    this.unregister();
-  },
-
-  unregister: function (key) {
-
-    if (key) {
-      delete this.dataModels[key];
-      delete this.createdModels[key];
-    } else {
-      this.dataModels = {};
-      this.createdModels = {};
-    }
-
-    return this;
-
-  },
-
-  generateOne: function (context, properties) {
-    return this.generate(context, 1, properties)[0];
-  },
-
-  generate: function (context, count, properties) {
-
-    count = count || 1;
-    var fixtures = [];
-
-    if (_.isObject(count)) {
-      properties = count;
-      count = 1;
-    }
-
-    while (fixtures.length < count) {
-      fixtures.push(_generateFixture.call(this, context, properties, fixtures));
-    }
-
-    // Store the created models, for further use by references
-    if (typeof context === 'string') {
-
-      if (this.createdModels[context] == null) {
-        this.createdModels[context] = [];
-      }
-
-      this.createdModels[context] = this.createdModels[context].concat(fixtures);
-    }
-
-    return fixtures;
+  if (isString) {
+    models[key] = dataModel;
+  }  else {
+    models = key;
   }
 
+  _.extend(this.dataModels, models);
+
+  this.emit('registered', models);
+
+  return this;
+};
+
+FixtureFactory.prototype.reset = function () {
+  this.unregister();
+};
+
+FixtureFactory.prototype.unregister = function (key) {
+  if (key) {
+    delete this.dataModels[key];
+    this.emit('unregistered', [key]);
+  } else {
+    this.emit('unregistered', Object.keys(this.dataModels));
+    this.dataModels = {};
+  }
+
+  return this;
+};
+
+FixtureFactory.prototype.generateOne = function (context, properties) {
+  var fixture = this.generate(context, 1, properties)[0];
+
+  return fixture;
+};
+
+FixtureFactory.prototype.generate = function (context, count, properties) {
+  var fixtures = [];
+
+  count = count || 1;
+
+  if (_.isObject(count)) {
+    properties = count;
+    count = 1;
+  }
+
+  while (fixtures.length < count) {
+    fixtures.push(this._generateFixture(context, properties, fixtures));
+  }
+
+  return fixtures;
 };
 
 instance = new FixtureFactory();

--- a/index.js
+++ b/index.js
@@ -51,44 +51,17 @@ FixtureFactory.prototype._handleString = function (model) {
   return isMethod ? nestedFakerMethod(options) : model.method;
 };
 
-FixtureFactory.prototype._formatNest = function (nested) {
-  var result = {};
-
-  if (_.isArray(nested)) {
-    result.context = nested[0];
-    result.count = nested[1] || 1;
-  } else if (_.isString(nested)) {
-    split = nested.split('.');
-    result.context = this.dataModels[split[0]];
-
-    if (split.length === 2) {
-      result.context = {};
-      result.context[split[1]] = this.dataModels[split[0]][split[1]];
-    }
-  } else if (nested.context){
-    result = nested;
-  } else {
-
-  }
-
-  return result;
-};
-
 FixtureFactory.prototype._generateField = function (
   key, method, fixture, dataModel, generatedFixtures
 ) {
   var fieldModel = this._getFieldModel(method);
-  var count;
+  var count = 1;
   var field;
 
   this.emit('field:pre', {
     name: key,
     model: fieldModel
   });
-
-  console.log(fieldModel);
-
-  var count = 1;
 
   switch (typeof fieldModel.method) {
     case 'function':

--- a/plugins/reference.js
+++ b/plugins/reference.js
@@ -3,27 +3,34 @@
 var _ = require('lodash');
 var factory;
 
+function _transform(model, split) {
+  var models = factory.dataModels;
+
+  model.method = models[split[1]];
+
+  if (split.length === 2) {
+    if (model.reference && model.reference.properties) {
+      model.method = _.extend(
+        model.method,
+        model.reference.properties
+      );
+    }
+  } else {
+    model.method = models[split[1]][split[2]];
+  }
+
+  return model;
+}
+
 function transform(event) {
   var model = event.model;
   var isRef = _.isString(model.method) &&  model.method.indexOf('model') === 0;
-  var models = factory.dataModels;
   var split;
 
   if (isRef) {
     split = model.method.split('.');
     if (split[0] === 'model') {
-      if (split.length === 2) {
-        model.method = models[split[1]];
-
-        if (model.reference && model.reference.properties) {
-          model.method = _.extend(
-            model.method,
-            model.reference.properties
-          );
-        }
-      } else {
-        model.method = models[split[1]][split[2]];
-      }
+      model = _transform(model, split);
     }
   }
 
@@ -36,7 +43,7 @@ module.exports.enable = function (fixtureFactory) {
   fixtureFactory.on('field:pre', transform);
 };
 
-module.exports.disable = function(fixtureFactory) {
+module.exports.disable = function (fixtureFactory) {
   factory.removeListener('field:pre', transform);
   factory = null;
 };

--- a/plugins/reference.js
+++ b/plugins/reference.js
@@ -33,8 +33,6 @@ function transform(event) {
       model = _transform(model, split);
     }
   }
-
-  return model;
 }
 
 module.exports.enable = function (fixtureFactory) {

--- a/plugins/reference.js
+++ b/plugins/reference.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var _ = require('lodash');
+var factory;
+
+function transform(event) {
+  var model = event.model;
+  var isRef = _.isString(model.method) &&  model.method.indexOf('model') === 0;
+  var models = factory.dataModels;
+  var split;
+
+  if (isRef) {
+    split = model.method.split('.');
+    if (split[0] === 'model') {
+      if (split.length === 2) {
+        model.method = models[split[1]];
+
+        if (model.reference && model.reference.properties) {
+          model.method = _.extend(
+            model.method,
+            model.reference.properties
+          );
+        }
+      } else {
+        model.method = models[split[1]][split[2]];
+      }
+    }
+  }
+
+  return model;
+}
+
+module.exports.enable = function (fixtureFactory) {
+  factory = fixtureFactory;
+
+  fixtureFactory.on('field:pre', transform);
+};
+
+module.exports.disable = function(fixtureFactory) {
+  factory.removeListener('field:pre', transform);
+  factory = null;
+};

--- a/test/fixture-factory.spec.js
+++ b/test/fixture-factory.spec.js
@@ -45,7 +45,7 @@ describe('Fixture Factory', function () {
 
   });
 
-  describe.only('Reference Plugin', function () {
+  describe('Reference Plugin', function () {
     it('should have a enable method', function () {
       expect(referencePlugin.enable).to.be.a('function');
     });
@@ -97,8 +97,6 @@ describe('Fixture Factory', function () {
 
       it('should provide the ability to pass properties to another model', function () {
         var fixture = fixtureFactory.generateOne('referencingModel');
-
-        console.log(fixture);
 
         expect(fixture.props.id).to.exist;
         expect(fixture.props.id).to.be.a('string');


### PR DESCRIPTION
I left the version at 1.4.1 because it was never published to npm and there are no breaking changes to what was supported in 1.4.0
- Convert to event emitter
- Allow for nested models without the nest
- improve api to avoid having to call generate again
- Reference plugin enabled by default that allows embedding model definitions and model field definitions for reuse
- Remove Reference using pre-built models (could be implemented via plugin)
- Removes unique and unique combine (could be implemented via plugin)
- Adjust tests to handle new nesting structure
- Remove un-supported tests
- Add tests for the reference plugin
